### PR TITLE
Add bigcode-tools to libraries page

### DIFF
--- a/tools/libs/index.md
+++ b/tools/libs/index.md
@@ -26,3 +26,20 @@ The repository also contains code to analyze Git-based repositories.
 </ul>
 <br/><span class="tags">Tags: #codeanalysis</span>
 </div>
+
+
+<div class="highlightitem">
+<h2>bigcode-tools</h2>
+
+bigcode-tools is a suite of tools to fetch, parse and process source code.
+It also contains utility to generate vector embeddings from source code.
+It currently supports Python 2 and 3, Java and JavaScript.
+The tools are designed to be compatible with <a href="http://www.srl.inf.ethz.ch/py150.php">py150</a> and <a href="http://www.srl.inf.ethz.ch/js150.php">js150</a> datasets.
+
+
+<ul>
+<li><a href="https://github.com/tuvistavie/bigcode-tools">bigcode-tools main repository</a></li>
+<li><a href="https://github.com/tuvistavie/bigcode-tools/blob/master/doc/tutorial.md">bigcode-tools tutorial</a></li>
+</ul>
+<br/><span class="tags">Tags: #codeanalysis #embeddings</span>
+</div>


### PR DESCRIPTION
I created a bunch of tools to work with "big code" as part of my current research and just open sourced them.
Everything quite well documented, but the toolset mostly allows to

1. Easily search and download source code
2. Parse source code to AST (Java, JavaScript and Python for now)
3. Generate nodes vector embeddings from ASTs

I wrote a [short tutorial](https://github.com/tuvistavie/bigcode-tools/blob/master/doc/tutorial.md) going step by step through most of the functionality.